### PR TITLE
Allow to process large zipfile as zip64 format

### DIFF
--- a/releasetools/sign_target_files_efis
+++ b/releasetools/sign_target_files_efis
@@ -326,7 +326,7 @@ def main(argv):
         common.Usage(__doc__)
         sys.exit(1)
 
-    output_zip = zipfile.ZipFile(args[1], "w")
+    output_zip = zipfile.ZipFile(args[1], "w", allowZip64=True)
 
     print "Extracting bootloader.zip"
     unpack_dir, input_zip = common.UnzipTemp(args[0])


### PR DESCRIPTION
If allowZip64 is False, there will be exception for large files more than 4GB.
Exception: zipfile.LargeZipFile: Zipfile size would require ZIP64 extensions.

Jira: None.
Test: Test it on KBL-NUC.

Signed-off-by: Zhou, Lihua <lihuax.zhou@intel.com>