### PR TITLE
ota: enable avb in resign scripts

### DIFF
--- a/releasetools/sign_target_files_efis
+++ b/releasetools/sign_target_files_efis
@@ -51,6 +51,9 @@ Usage: sign_target_files_efiss <options> <input_target_files_zip> <output_file>
       Expects a key pair assuming private key ends in .pk8 and public key
       with .x509.pem
 
+  -A  (--avb-key) <path>
+      Replace the Android Verified Boot key with the key in path
+
   -L  (--kernelflinger) <path>
       Path inside ESP to kernelflinger binary. Defaults to the first-stage loader.
 
@@ -192,8 +195,18 @@ def get_section(data, name):
 
     raise common.ExternalError("Section not found")
 
+def replace_raw_keys(data, raw_key, password):
+    (oemkeys_offset, oemkeys_size) = get_section(data, ".oemkeys")
 
-def replace_keys(data, oem_key_pair, password):
+    oem_key_file = open(raw_key, "rb")
+    oem_key_data = zero_pad(oem_key_file.read(), oemkeys_size)
+    oem_key_file.close()
+
+    data = (data[:oemkeys_offset] + oem_key_data +
+            data[oemkeys_offset + oemkeys_size:])
+    return data
+
+def replace_pem_keys(data, oem_key_pair, password):
     (oemkeys_offset, oemkeys_size) = get_section(data, ".oemkeys")
 
     oem_key_data_der_file = intel_common.pem_cert_to_der_cert(oem_key_pair +
@@ -204,7 +217,6 @@ def replace_keys(data, oem_key_pair, password):
     data = (data[:oemkeys_offset] + oem_key_data +
             data[oemkeys_offset + oemkeys_size:])
     return data
-
 
 def process_bootzip(input_bootzip, output_bootzip, passwords):
     for zi in input_bootzip.infolist():
@@ -223,7 +235,10 @@ def process_bootzip(input_bootzip, output_bootzip, passwords):
             password = None
             if OPTIONS.oem_key in passwords:
                 password = passwords[OPTIONS.oem_key]
-            data = replace_keys(data, OPTIONS.oem_key, password)
+            if OPTIONS.avb_key == None:
+                data = replace_pem_keys(data, OPTIONS.oem_key, password)
+            else:
+                data = replace_raw_keys(data, OPTIONS.avb_key, password)
 
         if path in OPTIONS.key_map:
             print "Re-signing", path
@@ -292,6 +307,9 @@ def main(argv):
             k,v = a.split("=")
             OPTIONS.key_map[k] = v
             OPTIONS.all_keys.add(v)
+        elif o in ("-A", "--avb-key"):
+            OPTIONS.avb_key = a
+            OPTIONS.all_keys.add(a)
         elif o in ("-R", "--replace"):
             k,v = a.split("=")
             OPTIONS.replace[k] = v
@@ -307,8 +325,8 @@ def main(argv):
         return True
 
     args = common.ParseOptions(argv, __doc__,
-            extra_opts = "k:R:F:O:K:L:",
-            extra_long_opts = ["key-mapping=",
+            extra_opts = "k:A:R:F:O:K:L:",
+            extra_long_opts = ["key-mapping=", "avb-key=",
                 "replace=", "first-stage=", "oem-key=", "kernelflinger="],
             extra_option_handler = option_handler)
 

--- a/test/ota-test-prepare
+++ b/test/ota-test-prepare
@@ -28,7 +28,9 @@ export TFP=
 export QUICK=
 export FORCE_BUILD_TFPS=
 export HAS_VARIANTS=
+export PRODUCT_OUT=out/target/product/${DEVICENAME}
 
+TOS_IMAGE_PARTITION_SIZE=10485760
 while getopts "qst:V:jlof" opt; do
     case $opt in
         s)
@@ -106,6 +108,22 @@ function has_variants {
     fi
 }
 
+avb_enable_string="BOARD_AVB_ENABLE := true"
+function check_avb {
+        product_dir=$(dirname $(find ${ANDROID_BUILD_TOP}/device/intel -name *.mk \
+                    ! \( -path "*/build/*" -prune \) ! \( -path "*/common/*" -prune \) \
+                    ! \( -path "*/mixins/*" -prune \) ! \( -path "*/sepolicy/*" -prune \) \
+                    -exec grep -l "PRODUCT_NAME := ${TARGET_PRODUCT}$" {} \;))
+        IS_AVB=$(grep "$avb_enable_string" ${product_dir}/BoardConfig.mk | wc -l || true)
+}
+
+function is_avb_enabled {
+    if [[ $IS_AVB -ge 1 ]]; then
+            return 0 # 0 is true
+    fi
+    return 1 # 1 is false
+}
+
 # Args: <input TFP> <output TFP>
 function sign_tfp {
     t1=`$MKTEMP tmp.tfp1.XXXXXXXX`
@@ -113,19 +131,49 @@ function sign_tfp {
 
     generate_verity_key -convert $PRODKEYS/verity.x509.pem $t2
 
-    ./build/tools/releasetools/sign_target_files_apks  \
-            --verbose \
-            --replace_ota_keys \
-            --replace_verity_public_key ${t2}.pub \
-            --replace_verity_private_key $PRODKEYS/verity \
-            --default_key_mappings $PRODKEYS $1 $t1
-    rm -f ${t2}.pub $t2
+    check_avb
 
-    ./device/intel/build/releasetools/sign_target_files_efis \
-            --verbose \
-            --oem-key $PRODKEYS/verity \
-            --key-mapping loader.efi=$PRODKEYS/DB \
-            $t1 $2
+    if is_avb_enabled; then
+        unzip $1 RADIO/tos.img -d $OTA_TMP_DIR
+
+        device/intel/build/test/unsign_boot_img.py $OTA_TMP_DIR/RADIO/tos.img > ${PRODUCT_OUT}/tos.img
+
+        avbtool add_hash_footer --image ${PRODUCT_OUT}/tos.img --partition_size $TOS_IMAGE_PARTITION_SIZE --partition_name tos --algorithm SHA256_RSA4096 --key $PRODKEYS/avb_releasekey.pem
+
+        avbtool extract_public_key --key $PRODKEYS/avb_releasekey.pem --output $OTA_TMP_DIR/avb_pk.bin
+
+        prebuilts/build-tools/linux-x86/bin/acp $PRODKEYS/avb_releasekey.pem external/avb/test/data/testkey_rsa4096.pem
+    fi
+
+    if is_avb_enabled; then
+        ./build/tools/releasetools/sign_target_files_apks  \
+                --verbose \
+                --replace_ota_keys \
+                --default_key_mappings $PRODKEYS $1 $t1
+        rm -f ${t2}.pub $t2
+
+        ./device/intel/build/releasetools/sign_target_files_efis \
+                --verbose \
+                --oem-key $PRODKEYS/verity \
+                --avb-key $OTA_TMP_DIR/avb_pk.bin \
+                --key-mapping loader.efi=$PRODKEYS/DB \
+                $t1 $2
+    else
+        ./build/tools/releasetools/sign_target_files_apks  \
+                --verbose \
+                --replace_ota_keys \
+                --replace_verity_public_key ${t2}.pub \
+                --replace_verity_private_key $PRODKEYS/verity \
+                --default_key_mappings $PRODKEYS $1 $t1
+        rm -f ${t2}.pub $t2
+
+        ./device/intel/build/releasetools/sign_target_files_efis \
+                --verbose \
+                --oem-key $PRODKEYS/verity \
+                --key-mapping loader.efi=$PRODKEYS/DB \
+                $t1 $2
+    fi
+
     rm $t1
 }
 


### PR DESCRIPTION
Test:
- resign cel_apl image: OK
- flash resigned cel_apl image on KBL NUC: OK
- OTA update with resign files: OK
- check that OTA update fails with not resigned OTA: OK

Tracked-On: OAM-71092
Signed-off-by: Regnier, Philippe <philippe.regnier@intel.com>