### PR TITLE
ota: fix ota after resign

### DIFF
--- a/releasetools/sign_target_files_efis
+++ b/releasetools/sign_target_files_efis
@@ -17,7 +17,7 @@
 """
 Re-sign EFI bootloader binaries found in RADIO/bootloader.zip with production
 keys. Can also substitute the vendor key inside the uefi_shim, or substitute
-a new shim entirely.
+a new shim entirely. If needed the resigned loader is copied to vendor partition.
 
 Usage: sign_target_files_efiss <options> <input_target_files_zip> <output_file>
 
@@ -77,6 +77,8 @@ from pyasn1.codec.ber import decoder as ber_decoder
 from pyasn1_modules import rfc5208 as pkcs8
 
 import json
+
+unpack_dir = ""
 
 if sys.hexversion < 0x02040000:
     print >> sys.stderr, "Python 2.4 or newer is required."
@@ -291,6 +293,15 @@ def process_bootzip(input_bootzip, output_bootzip, passwords):
                 output_bootzip.writestr("EFI/BOOT/bootx64.efi", data)
                 if OPTIONS.target_product == "coho":
                     output_bootzip.writestr("shim.efi", data)
+            if os.path.exists(os.path.join(unpack_dir, "VENDOR", "firmware", "kernelflinger.efi")):
+                if OPTIONS.verbose:
+                    print "Copy resigned kernelflinger.efi to ", os.path.join(unpack_dir, "VENDOR", "firmware", "kernelflinger.efi")
+                f = open(os.path.join(unpack_dir, "VENDOR", "firmware", "kernelflinger.efi"), "w")
+                f.write(data)
+                f.close()
+            else:
+                if OPTIONS.verbose:
+                    print "Path does not exist ", os.path.join(unpack_dir, "VENDOR", "firmware", "kernelflinger.efi")
 
 
 
@@ -347,6 +358,7 @@ def main(argv):
     output_zip = zipfile.ZipFile(args[1], "w")
 
     print "Extracting bootloader.zip"
+    global unpack_dir
     unpack_dir = common.UnzipTemp(args[0])
     input_zip = zipfile.ZipFile(args[0], "r")
     input_bootzip = zipfile.ZipFile(os.path.join(unpack_dir,
@@ -393,6 +405,8 @@ def main(argv):
     for zi in input_zip.infolist():
         if zi.filename == "RADIO/bootloader.zip":
             common.ZipWrite(output_zip, output_bz_file, zi.filename)
+        elif zi.filename == "VENDOR/firmware/kernelflinger.efi":
+            common.ZipWrite(output_zip, os.path.join(unpack_dir, "VENDOR", "firmware", "kernelflinger.efi"), zi.filename)
         elif zi.filename == "RADIO/fastboot.img":
             common.ZipWriteStr(output_zip, zi, fastboot.data)
         elif zi.filename == "RADIO/tdos.img":

--- a/test/ota-test-prepare
+++ b/test/ota-test-prepare
@@ -146,34 +146,34 @@ function sign_tfp {
     fi
 
     if is_avb_enabled; then
-        ./build/tools/releasetools/sign_target_files_apks  \
-                --verbose \
-                --replace_ota_keys \
-                --default_key_mappings $PRODKEYS $1 $t1
-        rm -f ${t2}.pub $t2
-
         ./device/intel/build/releasetools/sign_target_files_efis \
                 --verbose \
                 --oem-key $PRODKEYS/verity \
                 --avb-key $OTA_TMP_DIR/avb_pk.bin \
                 --key-mapping loader.efi=$PRODKEYS/DB \
-                $t1 $2
+                $1 $t1
+
+        ./build/tools/releasetools/sign_target_files_apks  \
+                --verbose \
+                --replace_ota_keys \
+                --default_key_mappings $PRODKEYS $t1 $2
+
     else
+        ./device/intel/build/releasetools/sign_target_files_efis \
+                --verbose \
+                --oem-key $PRODKEYS/verity \
+                --key-mapping loader.efi=$PRODKEYS/DB \
+                $1 $t1
+
         ./build/tools/releasetools/sign_target_files_apks  \
                 --verbose \
                 --replace_ota_keys \
                 --replace_verity_public_key ${t2}.pub \
                 --replace_verity_private_key $PRODKEYS/verity \
-                --default_key_mappings $PRODKEYS $1 $t1
-        rm -f ${t2}.pub $t2
-
-        ./device/intel/build/releasetools/sign_target_files_efis \
-                --verbose \
-                --oem-key $PRODKEYS/verity \
-                --key-mapping loader.efi=$PRODKEYS/DB \
-                $t1 $2
+                --default_key_mappings $PRODKEYS $t1 $2
     fi
 
+    rm -f ${t2}.pub $t2
     rm $t1
 }
 


### PR DESCRIPTION
kernelflinger.efi is added to vendor partition after resigning.
Partitions are now resigned after bootloader is signed and copied
to vendor directory in target file.

Test:
Boot to UI with resigned binaries
Boot to UI after OTA update with resigned binaries

Tracked-On: OAM-71983
Signed-off-by: phireg <philippe.regnier@intel.com>