### PR TITLE
ota: add support for zip files > 4GB

### DIFF
--- a/releasetools/sign_target_files_efis
+++ b/releasetools/sign_target_files_efis
@@ -359,7 +359,7 @@ def main(argv):
         common.Usage(__doc__)
         sys.exit(1)
 
-    output_zip = zipfile.ZipFile(args[1], "w")
+    output_zip = zipfile.ZipFile(args[1], "w", allowZip64=True)
 
     global unpack_dir
     unpack_dir = common.UnzipTemp(args[0])


### PR DESCRIPTION
Target files can be > 4 GB.
Resign scripts must support it.

Tracked-On: OAM-79935
Signed-off-by: phireg <philippe.regnier@intel.com>