### PR TITLE
ota: add support for zip files > 4GB

### DIFF
--- a/releasetools/sign_target_files_efis
+++ b/releasetools/sign_target_files_efis
@@ -355,7 +355,7 @@ def main(argv):
         common.Usage(__doc__)
         sys.exit(1)
 
-    output_zip = zipfile.ZipFile(args[1], "w")
+    output_zip = zipfile.ZipFile(args[1], "w", allowZip64=True)
 
     print "Extracting bootloader.zip"
     global unpack_dir

--- a/releasetools/sign_target_files_xbl
+++ b/releasetools/sign_target_files_xbl
@@ -397,7 +397,7 @@ def main(argv):
         common.Usage(__doc__)
         sys.exit(1)
 
-    output_zip = zipfile.ZipFile(args[1], "w")
+    output_zip = zipfile.ZipFile(args[1], "w", allowZip64=True)
 
     if OPTIONS.ifwi_directory.find("sbl") > 0:
         print "Using sbl"


### PR DESCRIPTION
Target files can be > 4 GB.
Resign scripts must support it.

Tracked-On: OAM-79935
Signed-off-by: phireg <philippe.regnier@intel.com>