### PR TITLE
ota: add build target publish_resign

### DIFF
--- a/tasks/resign.mk
+++ b/tasks/resign.mk
@@ -1,0 +1,12 @@
+otp := $(INTEL_PATH_BUILD)/test/ota-test-prepare
+
+.PHONY: publish_resign
+publish_resign: dist_files
+	export ANDROID_BUILD_TOP=$(PWD); $(otp) -o -s -t $(BUILT_TARGET_FILES_PACKAGE) resigned \
+	  && echo "Resign succeed" || { echo "Resign failed"; exit 0; }
+	@$(ACP) ota/$(TARGET_PRODUCT)/tfp-resigned.zip $(publish_dest) \
+	  && echo "tfp-resigned.zip copy succeed" || echo "tfp-resigned.zip copy failed"
+	@$(ACP) ota/$(TARGET_PRODUCT)/flashfiles-resigned.zip $(publish_dest) \
+	  && echo "flashfiles-resigned.zip copy succeed" || echo "flashfiles-resigned.zip copy failed"
+	@$(ACP) ota/$(TARGET_PRODUCT)/ota-resigned.zip $(publish_dest) \
+	  && echo "ota-resigned.zip copy succeed" || echo "ota-resigned.zip copy failed"

--- a/test/ota-test-prepare
+++ b/test/ota-test-prepare
@@ -44,6 +44,7 @@ export FORCE_BUILD_TFPS=
 export HAS_VARIANTS=
 export PRODUCT_OUT=out/target/product/${DEVICENAME}
 export HAS_SUPER=
+export OPENSSL_CONF=${OPENSSL_CONF:-/etc/ssl/openssl.cnf}
 
 TOS_IMAGE_PARTITION_SIZE=10485760
 while getopts "qst:V:jlof" opt; do


### PR DESCRIPTION
When called through build command, the new build target
publish_resign allows build system to automatically resign
current binaries and copy them in publish directory.
In case of failure of resign operation, other build
operations are not blocked and will perform normally.

Tracked-On: OAM-86894
Signed-off-by: phireg <philippe.regnier@intel.com>