### PR TITLE
Use host tar tool instead of tar from prebuilts

### DIFF
--- a/tasks/flashfiles.mk
+++ b/tasks/flashfiles.mk
@@ -244,7 +244,7 @@ flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) $(BUILT_RELEASE_FLASH_FILES_PACKA
 	$(hide) cp -r vendor/intel/utils/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) mv $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/patches
 	$(hide) cp -r $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/* $(TOP)
-	$(hide) tar --checkpoint=1000 --checkpoint-action=dot -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches caas*-flashfiles-*.zip
+	$(hide) tar -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches caas*-flashfiles-*.zip
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
 	$(hide) rm -rf $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz && rm -rf $(TOP)/Release_Files && rm -rf $(TOP)/caas*-flashfiles-*.zip && rm -rf $(TOP)/scripts && rm -rf $(TOP)/*patches && rm -rf $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
@@ -258,7 +258,7 @@ flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) publish_mkdir_dest publish_vertic
 	$(hide) cp -r vendor/intel/utils/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) mv $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/patches
 	$(hide) cp -r $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/* $(TOP)
-	$(hide) tar --checkpoint=1000 --checkpoint-action=dot -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches caas*-flashfiles-*.zip
+	$(hide) tar -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches caas*-flashfiles-*.zip
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
 	$(hide) rm -rf $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz && rm -rf $(TOP)/Release_Files && rm -rf $(TOP)/caas*-flashfiles-*.zip && rm -rf $(TOP)/scripts && rm -rf $(TOP)/*patches && rm -rf $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files

--- a/tasks/publish.mk
+++ b/tasks/publish.mk
@@ -31,7 +31,7 @@ PUB_SYSTEM_SYMBOLS := symbols.tar.gz
 $(PUB_SYSTEM_SYMBOLS): $(systemtarball)
 	@echo "Publish system symbols"
 	$(hide) mkdir -p $(publish_dest)
-	tar --checkpoint=1000 --checkpoint-action=dot -czf $(publish_dest)/$@ $(PRODUCT_OUT)/symbols
+	tar -czf $(publish_dest)/$@ $(PRODUCT_OUT)/symbols
 
 .PHONY: publish_system_symbols
 publish_system_symbols: $(PUB_SYSTEM_SYMBOLS)
@@ -43,7 +43,7 @@ PUB_QEMU_SCRIPTS := qemu_scripts.tar.gz
 $(PUB_QEMU_SCRIPTS): $(scriptstarball)
 	@echo "Publish scripts"
 	$(hide) mkdir -p $(publish_dest)
-	tar --checkpoint=1000 --checkpoint-action=dot -czf $(publish_dest)/$@ $(PRODUCT_OUT)/scripts
+	tar -czf $(publish_dest)/$@ $(PRODUCT_OUT)/scripts
 
 .PHONY: publish_qemu_scripts
 publish_qemu_scripts: $(PUB_QEMU_SCRIPTS)
@@ -70,7 +70,7 @@ PUB_KERNEL_MODULES = kernel_modules-$(TARGET_BUILD_VARIANT).tar.bz2
 $(PUB_KERNEL_MODULES): $(LOCAL_KERNEL_PATH)/copy_modules
 	@echo "Publish Kernel Modules"
 	$(hide) mkdir -p $(PUB_KERNEL_DBG_PATH)
-	-tar --checkpoint=1000 --checkpoint-action=dot -cjf $(PUB_KERNEL_DBG_PATH)/$@ -C $(LOCAL_KERNEL_PATH)/lib/modules .
+	-tar -cjf $(PUB_KERNEL_DBG_PATH)/$@ -C $(LOCAL_KERNEL_PATH)/lib/modules .
 
 publish_kernel_debug: $(PUB_KERNEL_DBG) $(PUB_KERNEL_MODULES)
 	@echo "Publish kernel debug: $(notdir $^)"


### PR DESCRIPTION
prebuilts tar has been enabled as part of enabling
setup path restrictions for Android 11. However
tar in prebuilts does not support --checkpoint option.
So using tar from host

Tracked-On: OAM-95316
Signed-off-by: yaravapa <yasoda.aravapalli@intel.com>