### PR TITLE
Add a new partition share_data

### DIFF
--- a/create_gpt_image.py
+++ b/create_gpt_image.py
@@ -520,6 +520,7 @@ class TableEntryInfos(object):
                       'mfos':'4f33cfe4-a0c1-448b-aec4-40f10a0cef3f',
                       'teedata': '0fc63daf-8483-4772-8e79-3d69d8477de4',
                       'super': '0fc63daf-8483-4772-8e79-3d69d8477de4',
+                      'share_data': '0fc63daf-8483-4772-8e79-3d69d8477de4',
                       'reserved': '0fc63daf-8483-4772-8e79-3d69d8477de4'
                       }
             }
@@ -876,6 +877,7 @@ class GPTImage(object):
         'mfos',
         'teedata',
         'super',
+        'share_data',
         'reserved'
         ]
 


### PR DESCRIPTION
/data partition cannot be used for mounting
overlayfs.

Created a new partition share_data to mount
overlayfs for docker related files.

Tracked-On: OAM-104201
Change-Id: Ibfd792e0cea68d8114ad8c56e60da7bb82d09c6a
Signed-off-by: nitishat9 <nitisha.tomar@intel.com>