### PR TITLE
Update valid build targets

### DIFF
--- a/tasks/flashfiles.mk
+++ b/tasks/flashfiles.mk
@@ -317,7 +317,7 @@ endif
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
 	@echo "Release files are published"
-ifneq (,$(filter  caas caas_dev caas_cfc,$(TARGET_PRODUCT)))
+ifneq (,$(filter caas,$(TARGET_PRODUCT)))
 ifneq (,$(wildcard out/dist))
 	@echo "Publish the CaaS image as debian_package"
 	$(hide)rm -rf $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release/
@@ -364,7 +364,7 @@ endif
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
 	@echo "Release files are published"
-ifneq (,$(filter  caas caas_dev caas_cfc,$(TARGET_PRODUCT)))
+ifneq (,$(filter caas,$(TARGET_PRODUCT)))
 ifneq (,$(wildcard out/dist))
 	@echo "Publish the CaaS image as debian package"
 	$(hide)rm -rf $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release/


### PR DESCRIPTION
Removed not supported caas_cfc and caas_dev targets.

Tracked-On: OAM-105021
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>