### PR TITLE
Add dynamic check and log when compressing release image

### DIFF
--- a/tasks/publish.mk
+++ b/tasks/publish.mk
@@ -155,7 +155,7 @@ ifdef GPTIMAGE_BIN
 ifeq ($(COMPRESS_GPTIMAGE), true)
 publish_gptimage: publish_mkdir_dest $(GPTIMAGE_BIN)
 	@echo compress $(GPTIMAGE_BIN) into $(GPTIMAGE_GZ)
-	@gzip -fk $(GPTIMAGE_BIN)
+	@gzip -fk $(GPTIMAGE_BIN) & PID=$!; echo "Waiting for $PID to complete"; while ps -p $PID > /dev/null; do echo "Process $PID is running"; sleep 20; done; echo "Process $PID is not running"
 	@$(ACP) $(GPTIMAGE_GZ) $(publish_dest)
 else # COMPRESS_GPTIMAGE is not true
 publish_gptimage: publish_mkdir_dest $(GPTIMAGE_BIN)


### PR DESCRIPTION
It takes a quite a long time to compress release image if image size is quite big, once time elapse of gzip process exceeds the threshold, it will be treated as no reponse or zombie.

Add logic to check the completion of compressing release image and print log if compressing is still in progress.