### PR TITLE
Improve compilation speed for android build

### DIFF
--- a/releasetools/bootloader_from_target_files
+++ b/releasetools/bootloader_from_target_files
@@ -62,9 +62,10 @@ def main(argv):
         sys.exit(1)
 
     print "unzipping target-files..."
-    OPTIONS.input_tmp = common.UnzipTemp(args[0])
-    input_zip = zipfile.ZipFile(args[0], "r")
-    OPTIONS.info_dict = common.LoadInfoDict(input_zip)
+    #OPTIONS.input_tmp = common.UnzipTemp(args[0])
+    OPTIONS.input_tmp = args[0]
+    #input_zip = zipfile.ZipFile(args[0], "r")
+    #OPTIONS.info_dict = common.LoadInfoDict(input_zip)
 
     extras = []
     if OPTIONS.bootable:

--- a/releasetools/flashfiles_from_target_files.sh
+++ b/releasetools/flashfiles_from_target_files.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+echo "========================"
+echo "Preparing flashfiles - New Method"
+echo "No more Zip. We use tar + pigz"
+echo "========================"
+
+## PRE-REQUISITE
+flashfile=`basename $1`
+flashfile_dir=`echo $flashfile | sed 's/\.tar\.gz//g'`
+PRODUCT_OUT=`dirname $1`
+VARIANT=`grep -i "ro.system.build.type=" $PRODUCT_OUT/system/build.prop | cut -d '=' -f2`
+TARGET=`grep -i "ro.build.product=" $PRODUCT_OUT/system/build.prop | cut -d '=' -f2`
+ANDROID_ROOT=${PWD}
+
+echo "========================"
+echo "Images / Files to be packed"
+echo "========================"
+IMAGES_TUPLE=`./device/intel/build/releasetools/flash_cmd_generator.py device/intel/project-celadon/$TARGET/flashfiles.ini $TARGET $VARIANT | tail -1`
+c=-2
+for i in $IMAGES_TUPLE
+do
+  if [[ $c -gt 0 && `expr $c % 2` == 1 ]]; then
+    i=`echo ${i::-3} | sed "s/'//g"`
+    echo $i
+    j="$j $i"
+  fi
+  c=$((c+1))
+done
+
+IMAGES=`echo $j | xargs -n1 | sort -u`
+echo "========================"
+echo "Generating Tar ..."
+echo "========================"
+cd $PRODUCT_OUT
+rm -rf $flashfile_dir
+mkdir $flashfile_dir
+
+for i in $IMAGES
+do
+  echo "Adding $i"
+  if [[ $i == "super.img" ]]; then
+    SUPER_IMG=true
+    cp ./obj/PACKAGING/super.img_intermediates/super.img $flashfile_dir/.
+  else
+    if [[ $i == "installer.efi" ]]; then
+      cp efi/installer.efi $flashfile_dir/.
+    else
+      if [[ $i == "startup.nsh" ]]; then
+        cp efi/startup.nsh $flashfile_dir/.
+      else
+	  if [[ $i == "system.img" || $i == "odm.img" || $i == "vbmeta.img" || $i == "vendor_boot.img" ]]; then
+	    cp obj/PACKAGING/target_files_intermediates/$TARGET-target_files-*/IMAGES/$i $flashfile_dir/.
+	  else
+            cp $i $flashfile_dir/.
+	  fi
+      fi
+    fi
+  fi
+done
+
+cd $ANDROID_ROOT
+echo "========================"
+echo "Generate installer.cmd"
+echo "========================"
+device/intel/build/releasetools/flash_cmd_generator.py device/intel/project-celadon/$TARGET/flashfiles.ini $TARGET $VARIANT | sed '$d' | sed '$d' | sed -n '/installer.cmd/,$p' | sed '1d' > $PRODUCT_OUT/$flashfile_dir/installer.cmd
+sed -i 's/flash super super.img/flash super super.img.part00 super.img.part01/g' $PRODUCT_OUT/$flashfile_dir/installer.cmd
+
+echo "========================"
+echo "Generate flash.json"
+echo "========================"
+device/intel/build/releasetools/flash_cmd_generator.py device/intel/project-celadon/$TARGET/flashfiles.ini $TARGET $VARIANT | sed -n '/installer.cmd/q;p' | sed '1d' > $PRODUCT_OUT/$flashfile_dir/flash.json
+
+if [[ $SUPER_IMG == "true" ]]; then
+  cd $PRODUCT_OUT
+  rm -f $flashfile_dir/system.img $flashfile_dir/vendor.img $flashfile_dir/product.img
+fi
+
+tar -cvf - $flashfile_dir/ | /usr/bin/pigz > $flashfile
+
+echo "========================"
+echo "Flashfiles Tar $PRODUCT_OUT/$flashfile_dir/$flashfile created"
+echo "========================"

--- a/tasks/flashfiles.mk
+++ b/tasks/flashfiles.mk
@@ -72,21 +72,28 @@ $(gpt_name):
 	@echo "skip build gptimages"
 endif
 
-$(BUILT_RELEASE_FLASH_FILES_PACKAGE):$(BUILT_RELEASE_SUPER_IMAGE) $(fftf) $(UEFI_ADDITIONAL_TOOLS)
+$(BUILT_RELEASE_FLASH_FILES_PACKAGE):$(BUILT_RELEASE_SUPER_IMAGE) $(legacy_fftf) $(UEFI_ADDITIONAL_TOOLS)
 	$(hide) mkdir -p $(dir $@)
-	$(fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) --add_image=$(BUILT_RELEASE_SUPER_IMAGE) $(BUILT_RELEASE_TARGET_FILES_PACKAGE) $@
+	$(legacy_fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) --add_image=$(BUILT_RELEASE_SUPER_IMAGE) $(BUILT_RELEASE_TARGET_FILES_PACKAGE) $@
 	#remove system.img vendor.img product.img from flashfiles.zip
 	$(hide)zip -d $@ "system.img" "product.img" "vendor.img";
 else
-$(BUILT_RELEASE_FLASH_FILES_PACKAGE):$(BUILT_RELEASE_TARGET_FILES_PACKAGE) $(fftf) $(UEFI_ADDITIONAL_TOOLS)
+$(BUILT_RELEASE_FLASH_FILES_PACKAGE):$(BUILT_RELEASE_TARGET_FILES_PACKAGE) $(legacy_fftf) $(UEFI_ADDITIONAL_TOOLS)
 	$(hide) mkdir -p $(dir $@)
-	$(fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) $(BUILT_RELEASE_TARGET_FILES_PACKAGE) $@
+	$(legacy_fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) $(BUILT_RELEASE_TARGET_FILES_PACKAGE) $@
 endif
 endif
 
 ifeq ($(USE_INTEL_FLASHFILES),true)
-fftf := $(INTEL_PATH_BUILD)/releasetools/flashfiles_from_target_files
+fftf := $(INTEL_PATH_BUILD)/releasetools/flashfiles_from_target_files.sh
+legacy_fftf := $(INTEL_PATH_BUILD)/releasetools/flashfiles_from_target_files
 odf := $(INTEL_PATH_BUILD)/releasetools/ota_deployment_fixup
+
+ifeq ($(use_tar),true)
+    fn_compress_format := tar.gz
+else
+    fn_compress_format := zip
+endif
 
 ifneq ($(FLASHFILE_VARIANTS),)
   # Generate variant specific flashfiles if VARIANT_SPECIFIC_FLASHFILES is True
@@ -96,17 +103,17 @@ ifneq ($(FLASHFILE_VARIANTS),)
 	    $(info Adding $(var)) \
 	    $(eval fn_prefix := $(PRODUCT_OUT)/$(TARGET_PRODUCT)) \
 	    $(eval fn_suffix := $(var)-$(FILE_NAME_TAG)) \
-	    $(eval ff_zip := $(fn_prefix)-flashfiles-$(fn_suffix).zip) \
+	    $(eval ff_zip := $(fn_prefix)-flashfiles-$(fn_suffix).$(fn_compress_format)) \
 	    $(eval INTEL_FACTORY_FLASHFILES_TARGET += $(ff_zip)) \
 	    $(call dist-for-goals,droidcore,$(ff_zip):$(notdir $(ff_zip))))
 
-	  $(INTEL_FACTORY_FLASHFILES_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(fftf) $(UEFI_ADDITIONAL_TOOLS)
+	  $(INTEL_FACTORY_FLASHFILES_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(fftf) $(legacy_fftf) $(UEFI_ADDITIONAL_TOOLS)
 	  $(hide) mkdir -p $(dir $@)
 	  $(eval y = $(subst -, ,$(basename $(@F))))
 	  $(eval DEV = $(word 3, $(y)))
 	  $(eval mvcfg_dev = $(MV_CONFIG_DEFAULT_TYPE.$(DEV)))
 	  $(if $(mvcfg_dev), $(eval mvcfg_default_arg = $(mvcfg_dev)),$(eval mvcfg_default_arg = $(MV_CONFIG_DEFAULT_TYPE)))
-	  $(hide) $(fftf) --variant=$(DEV) --mv_config_default=$(notdir $(mvcfg_default_arg)) $(BUILT_TARGET_FILES_PACKAGE) $@
+	  $(hide) $(legacy_fftf) --variant=$(DEV) --mv_config_default=$(notdir $(mvcfg_default_arg)) $(BUILT_TARGET_FILES_PACKAGE) $@
   endif
 
 ifneq ($(TARGET_SKIP_OTA_PACKAGE), true)
@@ -138,7 +145,11 @@ ifneq ($(FLASHFILE_VARIANTS),)
 FLASHFILES_ADD_ARGS := '--unified-variants'
 endif
 
-INTEL_FACTORY_FLASHFILES_TARGET := $(PRODUCT_OUT)/$(name).zip
+ifeq ($(use_tar),true)
+    INTEL_FACTORY_FLASHFILES_TARGET := $(PRODUCT_OUT)/$(name).tar.gz
+else
+    INTEL_FACTORY_FLASHFILES_TARGET := $(PRODUCT_OUT)/$(name).zip
+endif
 
 ifneq ($(SOFIA_FIRMWARE_VARIANTS),)
 mvcfg_default_arg = $(MV_CONFIG_DEFAULT_TYPE.$(firstword $(SOFIA_FIRMWARE_VARIANTS)))
@@ -146,16 +157,22 @@ else
 mvcfg_default_arg = $(MV_CONFIG_DEFAULT_TYPE)
 endif
 
+##########################################
+##########################################
 ifeq ($(SUPER_IMG_IN_FLASHZIP),true)
-$(INTEL_FACTORY_FLASHFILES_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(fftf) $(UEFI_ADDITIONAL_TOOLS) $(INTERNAL_SUPERIMAGE_DIST_TARGET)
+$(INTEL_FACTORY_FLASHFILES_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(fftf) $(legacy_fftf) $(UEFI_ADDITIONAL_TOOLS) $(INTERNAL_SUPERIMAGE_DIST_TARGET)
 	$(hide) mkdir -p $(dir $@)
-	$(fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) --add_image=$(INTERNAL_SUPERIMAGE_DIST_TARGET) $(BUILT_TARGET_FILES_PACKAGE) $@
+ifeq ($(use_tar),true)
+	$(fftf) $@
+else
+	$(legacy_fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) --add_image=$(INTERNAL_SUPERIMAGE_DIST_TARGET) $(BUILT_TARGET_FILES_PACKAGE) $@
 	#remove system.img vendor.img product.img from flashfiles.zip
 	$(hide)zip -d $@ "system.img" "product.img" "vendor.img";
+endif
 else
-$(INTEL_FACTORY_FLASHFILES_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(fftf) $(UEFI_ADDITIONAL_TOOLS)
+$(INTEL_FACTORY_FLASHFILES_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(legacy_fftf) $(UEFI_ADDITIONAL_TOOLS)
 	$(hide) mkdir -p $(dir $@)
-	$(fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) $(BUILT_TARGET_FILES_PACKAGE) $@
+	$(legacy_fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) $(BUILT_TARGET_FILES_PACKAGE) $@
 endif
 
 ifeq ($(PUBLISH_CMCC_IMG),true)
@@ -185,10 +202,10 @@ FAST_FLASHFILES_DEPS := \
     $(USERFASTBOOT_BOOTIMAGE) \
     $(INSTALLED_VBMETAIMAGE_TARGET) \
 
-fast_flashfiles: $(fftf) $(UEFI_ADDITIONAL_TOOLS) $(FAST_FLASHFILES_DEPS) | $(ACP)
+fast_flashfiles: $(fftf) $(legacy_fftf) $(UEFI_ADDITIONAL_TOOLS) $(FAST_FLASHFILES_DEPS) | $(ACP)
 	$(hide) rm -rf $(FAST_FLASHFILES_DIR)
 	$(hide) mkdir -p $(FAST_FLASHFILES_DIR)
-	$(fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) --fast $(PRODUCT_OUT) $(FAST_FLASHFILES_DIR)
+	$(legacy_fftf) $(FLASHFILES_ADD_ARGS) --mv_config_default=$(notdir $(mvcfg_default_arg)) --fast $(PRODUCT_OUT) $(FAST_FLASHFILES_DIR)
 
 # add dependencies
 droid: fast_flashfiles
@@ -294,7 +311,12 @@ else
 ISO_INSTALL_IMG = $(PRODUCT_OUT)/$(TARGET_PRODUCT)-flashfile-$(FILE_NAME_TAG).iso
 endif
 endif
-ISO_INSTALL_IMG_ZIP = $(ISO_INSTALL_IMG).zip
+
+ifeq ($(use_tar),true)
+ISO_INSTALL_IMG_COMP = $(ISO_INSTALL_IMG).tar.gz
+else
+ISO_INSTALL_IMG_COMP = $(ISO_INSTALL_IMG).zip
+endif
 ISO_RELEASE_TAR = $(PRODUCT_OUT)/$(TARGET_PRODUCT)-releasefile-$(TARGET_BUILD_VARIANT).iso.tar.gz
 ISO_EFI = $(PRODUCT_OUT)/iso_tmp.efi
 
@@ -308,7 +330,7 @@ flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) $(BUILT_RELEASE_FLASH_FILES_PACKA
 ifeq (,$(filter apollo_ivi blizzard_ivi base_aaos,$(TARGET_PRODUCT)))
 	@echo "Publishing Release files started ..."
 	$(hide) mkdir -p $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
-	$(hide) cp -r $(PRODUCT_OUT)/*-flashfiles-*.zip $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
+	$(hide) cp -r $(PRODUCT_OUT)/*-flashfiles-*.$(fn_compress_format) $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) cp -r $(PRODUCT_OUT)/scripts $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) cp -r vendor/intel/utils/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) mv $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/patches
@@ -316,12 +338,12 @@ ifeq (,$(filter apollo_ivi blizzard_ivi base_aaos,$(TARGET_PRODUCT)))
 ifneq (,$(wildcard vendor/intel/utils_vertical))
 ifneq (,$(wildcard vendor/intel/fw/keybox_provisioning))
 	@echo "vertical_keybox_provisioning included"
-	$(hide) tar --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.zip *provisioning
+	$(hide) tar --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.$(fn_compress_format) *provisioning
 else 
-	$(hide) tar --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.zip
+	$(hide) tar --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.$(fn_compress_format)
 endif
 else
-	$(hide) tar --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.zip
+	$(hide) tar --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.$(fn_compress_format)
 endif 	
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
@@ -357,7 +379,7 @@ flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) publish_gptimage_var publish_mkdi
 ifeq (,$(filter apollo_ivi blizzard_ivi base_aaos,$(TARGET_PRODUCT)))
 	@echo "Publishing Release files started"
 	$(hide) mkdir -p $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
-	$(hide) cp -r $(PRODUCT_OUT)/*-flashfiles-*.zip $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
+	$(hide) cp -r $(PRODUCT_OUT)/*-flashfiles-*.$(fn_compress_format) $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) cp -r $(PRODUCT_OUT)/scripts $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) cp -r vendor/intel/utils/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) mv $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/host $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files/patches
@@ -365,12 +387,12 @@ ifeq (,$(filter apollo_ivi blizzard_ivi base_aaos,$(TARGET_PRODUCT)))
 ifneq (,$(wildcard vendor/intel/utils_vertical))
 ifneq (,$(wildcard vendor/intel/fw/keybox_provisioning))
 	@echo "vertical_keybox_provisioning included"
-	$(hide) tar  --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.zip *provisioning
+	$(hide) tar  --exclude=*.git -cvf - scripts *patches $(TARGET_PRODUCT)-flashfiles-*.$(fn_compress_format) *provisioning | /usr/bin/pigz > $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz
 else
-	$(hide) tar  --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.zip
+	$(hide) tar  --exclude=*.git -cvf - scripts *patches $(TARGET_PRODUCT)-flashfiles-*.$(fn_compress_format) | /usr/bin/pigz > $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz
 endif
 else
-	$(hide) tar  --exclude=*.git -czf $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz scripts *patches $(TARGET_PRODUCT)-flashfiles-*.zip
+	$(hide) tar  --exclude=*.git -cvf - scripts *patches $(TARGET_PRODUCT)-flashfiles-*.$(fn_compress_format) | /usr/bin/pigz > $(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz
 endif
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
@@ -410,14 +432,18 @@ endif
 ifneq ($(iso_image),false)
 	@echo "Generating ISO image $(ISO_INSTALL_IMG) ...";
 	$(hide)rm -rf $(PRODUCT_OUT)/efi_images_tmp/;
-	$(hide)rm -rf $(ISO_INSTALL_IMG) $(ISO_INSTALL_IMG_ZIP)
+	$(hide)rm -rf $(ISO_INSTALL_IMG) $(ISO_INSTALL_IMG_COMP)
 	$(hide)mkdir -p $(PRODUCT_OUT)/efi_images_tmp;
 
+ifeq ($(use_tar),true)
+	cp -r $(PRODUCT_OUT)/$(TARGET_PRODUCT)-flashfiles-*/* $(PRODUCT_OUT)/efi_images_tmp/.
+else
 ifeq ($(RELEASE_BUILD),true)
 	$(hide)unzip $(BUILT_RELEASE_FLASH_FILES_PACKAGE) -d $(PRODUCT_OUT)/efi_images_tmp/ > /dev/null;
 else
 
 	$(hide)unzip $(INTEL_FACTORY_FLASHFILES_TARGET) -d $(PRODUCT_OUT)/efi_images_tmp/ > /dev/null;
+endif
 endif
 	G_size=`echo "$$((1 << 32))"`; \
 	for img in `ls $(PRODUCT_OUT)/efi_images_tmp/`;do \
@@ -447,8 +473,12 @@ endif
 	$(hide)xorriso -as mkisofs -iso-level 3  -r -V "Civ ISO" -J -joliet-long  -append_partition 2 0xef $(ISO_EFI) \
 	 -partition_cyl_align all -o $(ISO_INSTALL_IMG) $(PRODUCT_OUT)/iso/
 
-	@echo "Zipping ISO image $(ISO_INSTALL_IMG_ZIP) ..."
-	$(hide)zip -r -j $(ISO_INSTALL_IMG_ZIP) $(ISO_INSTALL_IMG)
+	@echo "Compress ISO image $(ISO_INSTALL_IMG_COMP) ..."
+ifeq ($(use_tar),true)
+	$(hide) tar -cvf - $(ISO_INSTALL_IMG) | /usr/bin/pigz > $(ISO_INSTALL_IMG_COMP)
+else
+	$(hide)zip -r -j $(ISO_INSTALL_IMG_COMP) $(ISO_INSTALL_IMG)
+endif
 ifeq (,$(filter  apollo_ivi blizzard_ivi base_aaos,$(TARGET_PRODUCT)))
 	@echo "Zipping ISO release image $(ISO_RELEASE_TAR) ..."
 	$(hide)rm -rf $(ISO_RELEASE_TAR)
@@ -456,22 +486,34 @@ ifeq (,$(filter  apollo_ivi blizzard_ivi base_aaos,$(TARGET_PRODUCT)))
 ifneq (,$(wildcard vendor/intel/utils_vertical))
 ifneq (,$(wildcard vendor/intel/fw/keybox_provisioning))
 	@echo "vertical_keybox_provisioning included"
+ifeq ($(use_tar),true)
+	$(hide) tar  --exclude=*.git -cvf - scripts *patches *-flashfile-*.iso *provisioning | /usr/bin/pigz > $(ISO_RELEASE_TAR)
+else
 	$(hide) tar  --exclude=*.git -czf $(ISO_RELEASE_TAR) scripts *patches *-flashfile-*.iso *provisioning
+endif
+else
+ifeq ($(use_tar),true)
+	$(hide) tar  --exclude=*.git -cvf - scripts *patches *-flashfile-*.iso | /usr/bin/pigz > $(ISO_RELEASE_TAR)
 else
 	$(hide) tar  --exclude=*.git -czf $(ISO_RELEASE_TAR) scripts *patches *-flashfile-*.iso
 endif
+endif
+else
+ifeq ($(use_tar),true)
+	$(hide) tar  --exclude=*.git -cvf - scripts *patches *-flashfile-*.iso | /usr/bin/pigz > $(ISO_RELEASE_TAR)
 else
 	$(hide) tar  --exclude=*.git -czf $(ISO_RELEASE_TAR) scripts *patches *-flashfile-*.iso
+endif
 endif
 endif
 	@echo "make ISO image done ---"
 ifeq (,$(filter  apollo_ivi blizzard_ivi base_aaos,$(TARGET_PRODUCT)))
 	$(hide) cp -r $(ISO_RELEASE_TAR) $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 endif
-	$(hide) cp -r $(ISO_INSTALL_IMG_ZIP) $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
+	$(hide) cp -r $(ISO_INSTALL_IMG_COMP) $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 
 	$(hide)rm -rf $(PRODUCT_OUT)/efi_images_tmp/ $(PRODUCT_OUT)/iso $(ISO_EFI)
 
 	@echo "ISO Release files are published"
 endif
-	$(hide)rm -rf $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz && rm -rf $(TOP)/Release_Files && rm -rf $(TOP)/$(TARGET_PRODUCT)-flashfiles-*.zip && rm -rf $(TOP)/scripts && rm -rf $(TOP)/*patches && rm -rf $(TOP)/*provisioning && rm -rf $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files $(TOP)/*-flashfile-*.iso
+	$(hide)rm -rf $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz && rm -rf $(TOP)/Release_Files && rm -rf $(TOP)/$(TARGET_PRODUCT)-flashfiles-*.$(fn_compress_format) && rm -rf $(TOP)/scripts && rm -rf $(TOP)/*patches && rm -rf $(TOP)/*provisioning && rm -rf $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files $(TOP)/*-flashfile-*.iso


### PR DESCRIPTION
Currently FFTF python script is used for creating flashfiles.zip. It uses ZipWrite python api which is time consuming and adds overhead to build time. Say, flash.json generation, unpacking of target files, installer.cmd generation, etc.

This fix helps to optimize build time and involves below changes:
- Use tar + pigz combo for faster flashfiles generation.
- Make FFTF a bash script as python doesn't directly support tar + pigz
- Add use_tar=true flag to "make flashfiles" to enable it. e,g, "make flashfiles -j<N> use_tar=true"
- The new script still supports all old functionalities, say, generation of installer.cmd, flash.json, repacking of bootloader.img, etc.

Tracked-On: OAM-112083