### PR TITLE
Remove directory while compressing android images

### DIFF
--- a/releasetools/flashfiles_from_target_files.sh
+++ b/releasetools/flashfiles_from_target_files.sh
@@ -76,7 +76,7 @@ if [[ $SUPER_IMG == "true" ]]; then
   rm -f $flashfile_dir/system.img $flashfile_dir/vendor.img $flashfile_dir/product.img
 fi
 
-tar -cvf - $flashfile_dir/ | /usr/bin/pigz > $flashfile
+tar -cvf - -C $flashfile_dir/ . | /usr/bin/pigz > $flashfile
 
 echo "========================"
 echo "Flashfiles Tar $PRODUCT_OUT/$flashfile_dir/$flashfile created"

--- a/tasks/flashfiles.mk
+++ b/tasks/flashfiles.mk
@@ -319,6 +319,8 @@ ISO_INSTALL_IMG_COMP = $(ISO_INSTALL_IMG).zip
 endif
 ISO_RELEASE_TAR = $(PRODUCT_OUT)/$(TARGET_PRODUCT)-releasefile-$(TARGET_BUILD_VARIANT).iso.tar.gz
 ISO_EFI = $(PRODUCT_OUT)/iso_tmp.efi
+iso_basename = $(shell basename $(ISO_INSTALL_IMG))
+iso_path = $(shell dirname $(ISO_INSTALL_IMG))
 
 LOCAL_TOOL:= \
    PATH="/bin:$$PATH"
@@ -475,7 +477,7 @@ endif
 
 	@echo "Compress ISO image $(ISO_INSTALL_IMG_COMP) ..."
 ifeq ($(use_tar),true)
-	$(hide) tar -cvf - $(ISO_INSTALL_IMG) | /usr/bin/pigz > $(ISO_INSTALL_IMG_COMP)
+	$(hide) tar -cvf - -C $(iso_path) $(iso_basename) | /usr/bin/pigz > $(ISO_INSTALL_IMG_COMP)
 else
 	$(hide)zip -r -j $(ISO_INSTALL_IMG_COMP) $(ISO_INSTALL_IMG)
 endif


### PR DESCRIPTION
directory is not required in final release packages

Test done:
	make flashfiles use_tar=true
	uzip flashfile.tar.gz and iso.tar.gz, no
	directory in extracted files

Tracked-On: OAM-115250