### PR TITLE
Add gpt.ini to flashfiles

### DIFF
--- a/releasetools/flashfiles_from_target_files.sh
+++ b/releasetools/flashfiles_from_target_files.sh
@@ -48,6 +48,8 @@ do
     else
       if [[ $i == "startup.nsh" ]]; then
         cp efi/startup.nsh $flashfile_dir/.
+      elif [[ $i == "gpt.ini" ]]; then
+        cp obj/PACKAGING/flashfiles_intermediates/root/$i $flashfile_dir/.
       else
 	  if [[ $i == "system.img" || $i == "odm.img" || $i == "vbmeta.img" || $i == "vendor_boot.img" ]]; then
 	    cp obj/PACKAGING/target_files_intermediates/$TARGET-target_files-*/IMAGES/$i $flashfile_dir/.
@@ -79,5 +81,5 @@ fi
 tar -cvf - -C $flashfile_dir/ . | /usr/bin/pigz > $flashfile
 
 echo "========================"
-echo "Flashfiles Tar $PRODUCT_OUT/$flashfile_dir/$flashfile created"
+echo "Flashfiles Tar $PRODUCT_OUT/$flashfile created"
 echo "========================"


### PR DESCRIPTION
gpt.ini is used to flash android images, add it to flashfiles to optimize the flash steps

Test done:
make flashfiles
make flashfiles use_tar=true

Tracked-On: OAM-115800