### PR TITLE
Remove release files for base_aaos to optimize compile speed and save…

### DIFF
--- a/tasks/flashfiles.mk
+++ b/tasks/flashfiles.mk
@@ -297,6 +297,7 @@ LOCAL_TOOL:= \
 ifeq ($(RELEASE_BUILD),true)
 flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) $(BUILT_RELEASE_FLASH_FILES_PACKAGE) $(gpt_name) publish_mkdir_dest publish_vertical host-pkg
 	@$(ACP) $(BUILT_RELEASE_FLASH_FILES_PACKAGE) $(publish_dest)
+ifeq (,$(filter  base_aaos,$(TARGET_PRODUCT)))
 	@echo "Publishing Release files started ..."
 	$(hide) mkdir -p $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) cp -r $(PRODUCT_OUT)/*-flashfiles-*.zip $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
@@ -317,6 +318,7 @@ endif
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
 	@echo "Release files are published"
+endif
 ifneq (,$(filter caas,$(TARGET_PRODUCT)))
 ifneq (,$(wildcard out/dist))
 	@echo "Publish the CaaS image as debian_package"
@@ -344,6 +346,7 @@ else
 endif
 else
 flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) publish_gptimage_var publish_mkdir_dest publish_vertical host-pkg
+ifeq (,$(filter  base_aaos,$(TARGET_PRODUCT)))
 	@echo "Publishing Release files started"
 	$(hide) mkdir -p $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
 	$(hide) cp -r $(PRODUCT_OUT)/*-flashfiles-*.zip $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files
@@ -364,6 +367,7 @@ endif
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 	$(hide) cp -r $(TOP)/$(TARGET_PRODUCT)-releasefiles-$(TARGET_BUILD_VARIANT).tar.gz $(PRODUCT_OUT)
 	@echo "Release files are published"
+endif
 ifneq (,$(filter caas,$(TARGET_PRODUCT)))
 ifneq (,$(wildcard out/dist))
 	@echo "Publish the CaaS image as debian package"
@@ -437,6 +441,7 @@ endif
 	@echo "Zipping ISO image $(ISO_INSTALL_IMG_ZIP) ..."
 	$(hide)zip -r -j $(ISO_INSTALL_IMG_ZIP) $(ISO_INSTALL_IMG)
 
+ifeq (,$(filter  base_aaos,$(TARGET_PRODUCT)))
 	@echo "Zipping ISO release image $(ISO_RELEASE_TAR) ..."
 	$(hide)rm -rf $(ISO_RELEASE_TAR)
 	$(hide)cp $(ISO_INSTALL_IMG) $(TOP)/
@@ -450,9 +455,11 @@ endif
 else
 	$(hide) tar  --exclude=*.git -czf $(ISO_RELEASE_TAR) scripts *patches *-flashfile-*.iso
 endif
-
+endif
 	@echo "make ISO image done ---"
+ifeq (,$(filter  base_aaos,$(TARGET_PRODUCT)))
 	$(hide) cp -r $(ISO_RELEASE_TAR) $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
+endif
 	$(hide) cp -r $(ISO_INSTALL_IMG_ZIP) $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)
 
 	$(hide)rm -rf $(PRODUCT_OUT)/efi_images_tmp/ $(PRODUCT_OUT)/iso $(ISO_EFI)


### PR DESCRIPTION
… storage

Release files are mainly used for CIV host setup. They are useless for IVI target.

Tracked-On: OAM-117722