### PR TITLE
Solve build failure for release build

### DIFF
--- a/tasks/flashfiles.mk
+++ b/tasks/flashfiles.mk
@@ -35,7 +35,7 @@ APEX_LIST := com.android.tethering.apex,\
 			 com.android.i18n.apex
 BUILT_APEXS := $(subst $(space),,$(APEX_LIST))
 
-$(BUILT_RELEASE_TARGET_FILES_PACKAGE):$(BUILT_TARGET_FILES_PACKAGE)
+$(BUILT_RELEASE_TARGET_FILES_PACKAGE):$(BUILT_TARGET_FILES_PACKAGE) sign_target_files_apks
 	@echo "Package release: $@"
 	$(SOONG_HOST_TOOL) \
 	$(HOST_OUT_EXECUTABLES)/sign_target_files_apks -o \


### PR DESCRIPTION
Release build depends on sign_target_files_apks
target which is used for OTA(cmd: make dist)

fix below build failure:
make flashfiles -j100 publish_gptimage RELEASE_BUILD=true iso_image=false use_tar=true

Tracked-On: OAM-123548