### PR TITLE
Separate GPT table as read-only and read-write

### DIFF
--- a/releasetools/flashfiles_from_target_files.sh
+++ b/releasetools/flashfiles_from_target_files.sh
@@ -27,7 +27,7 @@ echo "========================"
 echo "Images / Files to be packed"
 echo "========================"
 IMAGES_TUPLE=`./device/intel/build/releasetools/flash_cmd_generator.py device/intel/project-celadon/$TARGET/flashfiles.ini $TARGET $VARIANT | tail -1`
-c=-2
+c=0
 for i in $IMAGES_TUPLE
 do
   if [[ $c -gt 0 && `expr $c % 2` == 1 ]]; then
@@ -62,7 +62,7 @@ do
 		else
 			if [[ $i == "startup.nsh" ]]; then
 				cp efi/startup.nsh $flashfile_dir/.
-			elif [[ $i == "gpt.ini" ]]; then
+			elif [[ $i == "gpt.ini"  || $i == "gpt_ro.bin" || $i == "gpt_rw.bin" || $i == "gpt_rw_nolic.bin" ]]; then
 				cp obj/PACKAGING/flashfiles_intermediates/root/$i $flashfile_dir/.
 			else
 				if [[ $i == "boot.img" || $i == "odm.img" || $i == "vbmeta.img" || $i == "vendor_boot.img" ]]; then


### PR DESCRIPTION
These partition tables will be used in android flash if android image is devided into read-only image
and read-write image

Test Done:
make flashfiles to generate gpt_ro.bin gpt_rw.bin
and gpt_rw_nolic.bin
Flash these gpt tables to device through fastboot
and boot success

Tracked-On: OAM-124748