### PR TITLE
Introduce more sepolicy treble compliant test for flashfiles build

### DIFF
--- a/tasks/flashfiles.mk
+++ b/tasks/flashfiles.mk
@@ -334,7 +334,7 @@ LOCAL_TOOL:= \
 
 .PHONY: flashfiles
 ifeq ($(RELEASE_BUILD),true)
-flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) $(BUILT_RELEASE_FLASH_FILES_PACKAGE) $(gpt_name) publish_mkdir_dest publish_vertical host-pkg sepolicy_freeze_test check-vintf-all
+flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) $(BUILT_RELEASE_FLASH_FILES_PACKAGE) $(gpt_name) publish_mkdir_dest publish_vertical host-pkg selinux_policy check-vintf-all
 	@$(ACP) $(BUILT_RELEASE_FLASH_FILES_PACKAGE) $(publish_dest)
 ifeq (,$(filter  base_aaos aaos_iasw,$(TARGET_PRODUCT)))
 	@echo "Publishing Release files started ..."
@@ -384,7 +384,7 @@ else
 	$(hide)rm -rf $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release
 endif
 else
-flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) publish_gptimage_var publish_mkdir_dest publish_vertical host-pkg sepolicy_freeze_test check-vintf-all
+flashfiles: $(INTEL_FACTORY_FLASHFILES_TARGET) publish_gptimage_var publish_mkdir_dest publish_vertical host-pkg selinux_policy check-vintf-all
 ifeq (,$(filter  base_aaos aaos_iasw,$(TARGET_PRODUCT)))
 	@echo "Publishing Release files started"
 	$(hide) mkdir -p $(TOP)/pub/$(TARGET_PRODUCT)/$(TARGET_BUILD_VARIANT)/Release_Files


### PR DESCRIPTION
selinux_policy will introduce more sepolicy compliant tests for flashfiles build which is important for the sepolicy rules development.

Tracked-On: OAM-128247