### PR TITLE
Add gpt.ini to flashfiles images

### DIFF
--- a/releasetools/flashfiles_from_target_files.sh
+++ b/releasetools/flashfiles_from_target_files.sh
@@ -48,9 +48,11 @@ do
     else
       if [[ $i == "startup.nsh" ]]; then
         cp efi/startup.nsh $flashfile_dir/.
+      elif [[ $i == "gpt.ini" ]]; then
+        cp obj/PACKAGING/flashfiles_intermediates/root/$i $flashfile_dir/.
       else
-	  if [[ $i == "system.img" || $i == "odm.img" || $i == "vbmeta.img" || $i == "vendor_boot.img" ]]; then
-	    cp obj/PACKAGING/target_files_intermediates/$TARGET-target_files-*/IMAGES/$i $flashfile_dir/.
+	  if [[ $i == "boot.img" || $i == "vbmeta.img" || $i == "vendor_boot.img" ]]; then
+	    cp obj/PACKAGING/target_files_intermediates/$TARGET-target_files*/IMAGES/$i $flashfile_dir/.
 	  else
             cp $i $flashfile_dir/.
 	  fi


### PR DESCRIPTION
The gpt.ini file is a GPT configuration file used
during the Android flashing process in the SOS environment. Each build may have different partition tables.
We need these GPT files to prevent flashing failures

Test Done:
make flashfiles use_tar=true
Flash and boot success

Tracked-On: OAM-128461