### PR TITLE
Updating the clang path according to new clang lib

### DIFF
--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -107,9 +107,9 @@ IAFW_CC := $(IAFW_TOOLS_CLANG_PREFIX)/clang
 IAFW_OBJCOPY := $(IAFW_TOOLS_GCC_PREFIX)objcopy$(HOST_EXECUTABLE_SUFFIX)
 EFI_OBJCOPY := $(IAFW_OBJCOPY)
 ifeq ($(TARGET_IAFW_ARCH),x86_64)
-IAFW_LIBCLANG := $(IAFW_TOOLCHAIN_CLANG_ROOT)/../lib/clang/18/lib/linux/libclang_rt.builtins-x86_64-android.a
+IAFW_LIBCLANG := $(IAFW_TOOLCHAIN_CLANG_ROOT)/../lib/clang/19/lib/linux/libclang_rt.builtins-x86_64-android.a
 else
-IAFW_LIBCLANG := $(IAFW_TOOLCHAIN_CLANG_ROOT)/../lib/clang/18/lib/linux/libclang_rt.builtins-i686-android.a
+IAFW_LIBCLANG := $(IAFW_TOOLCHAIN_CLANG_ROOT)/../lib/clang/19/lib/linux/libclang_rt.builtins-i686-android.a
 endif
 
 # Transformation definitions, ala build system's definitions.mk


### PR DESCRIPTION
This patch will update the clang patch to 19 as
we are moving to latest clang with A15 tag r9 update.

Tests Done: Build and boot

Tracked-On: OAM-128386