### PR TITLE
Define the cts-release-test key path.

### DIFF
--- a/testkeys/cts-release-test/Android.bp
+++ b/testkeys/cts-release-test/Android.bp
@@ -1,0 +1,27 @@
+//package {
+    // See: http://go/android-license-faq
+    // A large-scale-change added 'default_applicable_licenses' to import
+    // all of the 'license_kinds' from "vendor_widevine_license"
+    // to get the below license kinds:
+    //   SPDX-license-identifier-Apache-2.0
+    //   legacy_by_exception_only (by exception only)
+    //   legacy_proprietary (by exception only)
+    //default_applicable_licenses: ["vendor_widevine_license"],
+//}
+
+filegroup {
+    name: "com.google.android.widevine.public_key",
+    srcs: [ "apex.avbpubkey" ],
+}
+
+filegroup {
+    name: "com.google.android.widevine.private_key",
+    srcs: [ "apex.pem" ],
+}
+
+android_app_certificate {
+    name: "com.google.android.widevine.certificate",
+    certificate: "apex",
+}
+
+


### PR DESCRIPTION
The cts release test key will be used to widevine apex
since there are key issues when running cts CtsSecurityTestCases
android.security.cts.PackageSignatureTest#testPackageSignatures

Test Done:
  run cts CtsSecurityTestCases

Tracked-On: OAM-125839